### PR TITLE
Rename prepare_for_encoding->to_dynamic and make it public

### DIFF
--- a/src/gleam/jsone.gleam
+++ b/src/gleam/jsone.gleam
@@ -184,7 +184,7 @@ pub fn object(object: List(tuple(String, JsonValue))) -> JsonValue {
   JsonObject(object)
 }
 
-fn prepare_for_encoding(json_value: JsonValue) -> Dynamic {
+pub fn to_dynamic(json_value: JsonValue) -> Dynamic {
   case json_value {
     JsonString(string) -> dynamic.from(string)
     JsonNumber(json_number) ->
@@ -194,7 +194,7 @@ fn prepare_for_encoding(json_value: JsonValue) -> Dynamic {
       }
     JsonArray(list) ->
       list
-      |> list_mod.map(prepare_for_encoding)
+      |> list_mod.map(to_dynamic)
       |> dynamic.from
     JsonNull ->
       "null"
@@ -203,7 +203,7 @@ fn prepare_for_encoding(json_value: JsonValue) -> Dynamic {
     JsonBool(bool) -> dynamic.from(bool)
     JsonObject(object) ->
       object
-      |> list_mod.map(pair.map_second(_, prepare_for_encoding))
+      |> list_mod.map(pair.map_second(_, to_dynamic))
       |> map.from_list
       |> dynamic.from
   }
@@ -222,7 +222,7 @@ fn jsone_try_decoder() -> Decoder(Dynamic) {
 /// Encode a JSON value as a UTF-8 binary.
 pub fn encode(json_value: JsonValue) -> Result(Dynamic, String) {
   json_value
-  |> prepare_for_encoding
+  |> to_dynamic
   |> jsone_try_encode
   |> decode_dynamic(jsone_try_decoder())
 }


### PR DESCRIPTION
As far as I understand, right now library allows to encode a Gleam object to a JSON string. Sometimes it is useful to get an Erlang/Elixir map though.

I'm writing an integration with AWS DynamoDB and the external Elixir library expects a map that will be encoded to JSON string by library itself later. This input looks like that:

```elixir
%{
  "TableName" => "some-table",
  "Item" => %{"attribute" => %{"S" => "value"}}
}
```

If `prepare_for_encoding` (or `to_dynamic` after rename) would be a public function, I could implement it like that:

```gleam
external fn do_put_item(Client, Dynamic) -> Dynamic =
  "Elixir.AWS.DynamoDB" "put_item"

pub fn put_item(
  aws_client: Client,
  table: String,
  item: JsonValue,
) -> Dynamic {
  let input =
    [tuple("TableName", jsone.string(table)), tuple("Item", item)]
    |> jsone.object()
    |> jsone.to_dynamic()


  do_put_item(aws_client, input)
}
```

What do you think about such change?